### PR TITLE
quick fix: Update blocks/day for post-merge

### DIFF
--- a/packages/nouns-webapp/src/index.tsx
+++ b/packages/nouns-webapp/src/index.tsx
@@ -111,7 +111,7 @@ const Updaters = () => {
   );
 };
 
-const BLOCKS_PER_DAY = 6_500;
+const BLOCKS_PER_DAY = 7_145;
 
 const ChainSubscriber: React.FC = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
Post-merge, Ethereum blocks/day increased by about 1000 and mathematically should be exactly every 12 seconds, so 7,200/day. But realistically it's usually been a little bit lower, so I went with 7_145 based on historical data https://ycharts.com/indicators/ethereum_blocks_per_day.

Impact should be low, but a necessary change for us to more accurately show # of bids in a day